### PR TITLE
Sora: Version 2.000 added; Gelasio: Version 1.006 added

### DIFF
--- a/ofl/sora/METADATA.pb
+++ b/ofl/sora/METADATA.pb
@@ -20,3 +20,7 @@ axes {
   min_value: 100.0
   max_value: 800.0
 }
+source {
+  repository_url: "https://github.com/sora-xor/sora-font.git"
+  commit: "efeb79b4eff1090588196321b53bc9fea722d6f9"
+}

--- a/ofl/sora/upstream.yaml
+++ b/ofl/sora/upstream.yaml
@@ -1,0 +1,31 @@
+# For more help see the docs at:
+# https://github.com/googlefonts/gf-docs/tree/master/METADATA
+
+# Full family name, with initial upper cases and spaces
+name: Sora
+
+# In most cases this should be based on the GitHub https repo url:
+# this https://github.com/{owner}/{repo}.git
+repository_url: https://github.com/sora-xor/sora-font.git
+
+# The branch name used to update google fonts. e.g.: master
+branch: master
+
+# Choose one of: DISPLAY, SERIF, SANS_SERIF, SANS_SERIF, HANDWRITING, MONOSPACE
+category: SANS_SERIF
+
+# Full name of the type designer(s) or foundry who designed the fonts.
+designer: Jonathan Barnbrook, Julián Moncada
+
+# Dictionary mapping of SOURCE file names to TARGET file names. Where
+files:
+  OFL.txt: OFL.txt
+  DESCRIPTION.en_us.html: DESCRIPTION.en_us.html
+  fonts/variable/Sora[wght].ttf: Sora[wght].ttf
+  fonts/ttf/Sora-Bold.ttf: static/Sora-Bold.ttf
+  fonts/ttf/Sora-ExtraBold.ttf: static/Sora-ExtraBold.ttf
+  fonts/ttf/Sora-ExtraLight.ttf: static/Sora-ExtraLight.ttf
+  fonts/ttf/Sora-Light.ttf: static/Sora-Light.ttf
+  fonts/ttf/Sora-Regular.ttf: static/Sora-Regular.ttf
+  fonts/ttf/Sora-SemiBold.ttf: static/Sora-SemiBold.ttf
+  fonts/ttf/Sora-Thin.ttf: static/Sora-Thin.ttf


### PR DESCRIPTION
* Sora Version 2.000 taken from the upstream repo https://github.com/sora-xor/sora-font.git at commit https://github.com/sora-xor/sora-font/commit/efeb79b4eff1090588196321b53bc9fea722d6f9.
* Gelasio Version 1.006 taken from the upstream repo https://github.com/SorkinType/Gelasio.git at commit https://github.com/SorkinType/Gelasio/commit/c709e349ff6ce37a3381f4eaecef0b5d91d72eae.